### PR TITLE
convert ArrayBuffers to Buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var through2 = require("through2")
+var toBuffer = require("typedarray-to-buffer")
 
 module.exports = DataChannel
 
@@ -54,7 +55,11 @@ function DataChannel(channel) {
     }
 
     function onmessage(message) {
-        stream.push(message.data)
+        var data = message.data
+        if (data instanceof ArrayBuffer) {
+            data = toBuffer(new Uint8Array(data))
+        }
+        stream.push(data)
     }
 
     function onerror(err) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "through2": "~0.4.1"
+    "through2": "~0.4.1",
+    "typedarray-to-buffer": "^3.0.1"
   },
   "devDependencies": {
     "tap": "~0.3.1"


### PR DESCRIPTION
Binary message data comes through as an ArrayBuffer chunk, which streams don't seem to like. This patch just does what [simple-peer](https://github.com/feross/simple-peer/blob/master/index.js#L317) does.
